### PR TITLE
docs: add details for adding a new server in pgadmin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,9 @@ This Compose file contains the following environment variables:
 * **URL:** `http://localhost:5050`
 * **Username:** pgadmin4@pgadmin.org (as a default)
 * **Password:** admin (as a default)
+
+## Add a new server in PgAdmin:
+* **Host name/address** `postgres`
+* **Port** `5432`
+* **Username** as `POSTGRES_USER`, by default: `postgres`
+* **Password** as `POSTGRES_PASSWORD`, by default `changeme`


### PR DESCRIPTION
I would like to propose an additional note in the documentation to provide an example on how to configure a new server connection in pgadmin. I took me a while to figure this out as I assumed that `localhost` or `127.0.0.1` would work but it didn't. This is to spare others the same trouble.