### PR TITLE
Rename "PGADMIN_PORT" to "PGADMIN_LISTEN_PORT"

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This Compose file contains the following environment variables:
 
 * `POSTGRES_USER` the default value is **postgres**
 * `POSTGRES_PASSWORD` the default value is **changeme**
-* `PGADMIN_PORT` the default value is **5050**
+* `PGADMIN_LISTEN_PORT` the default value is **5050**
 * `PGADMIN_DEFAULT_EMAIL` the default value is **pgadmin4@pgadmin.org**
 * `PGADMIN_DEFAULT_PASSWORD` the default value is **admin**
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     volumes:
        - pgadmin:/root/.pgadmin
     ports:
-      - "${PGADMIN_PORT:-5050}:80"
+      - "${PGADMIN_LISTEN_PORT:-5050}:80"
     networks:
       - postgres
     restart: unless-stopped


### PR DESCRIPTION
According to the image documentation (found [here](https://www.pgadmin.org/docs/pgadmin4/latest/container_deployment.html)), the variable `PGADMIN_PORT` does not exist. `PGADMIN_LISTEN_PORT` should be used instead.