### PR TITLE
Mounted pgadmin storage to host machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/pg_storage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin}
     volumes:
        - pgadmin:/root/.pgadmin
+       - ./pg_storage:/var/lib/pgadmin/storage
     ports:
       - "${PGADMIN_PORT:-5050}:80"
     networks:
@@ -37,3 +38,4 @@ networks:
 volumes:
     postgres:
     pgadmin:
+    pg_storage:


### PR DESCRIPTION
I believe a lot of people might use this to get up and going quickly. PGAdmin saves files locally, in the respective docker volumes. I think it would be a good idea to mount the storage to the machine, such that queries can be added and saved seamlessly. 