### PR TITLE
Pgadmin server mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-/pg_storage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,6 @@ services:
       PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin}
     volumes:
        - pgadmin:/root/.pgadmin
-       - ./pg_storage:/var/lib/pgadmin/storage
     ports:
       - "${PGADMIN_PORT:-5050}:80"
     networks:
@@ -38,4 +37,3 @@ networks:
 volumes:
     postgres:
     pgadmin:
-    pg_storage:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,12 +18,14 @@ services:
   
   pgadmin:
     container_name: pgadmin_container
-    image: dpage/pgadmin4
+    image: dpage/pgadmin4:4.16
     environment:
       PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-pgadmin4@pgadmin.org}
       PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin}
+      PGADMIN_CONFIG_SERVER_MODE: 'False'
     volumes:
        - pgadmin:/root/.pgadmin
+
     ports:
       - "${PGADMIN_PORT:-5050}:80"
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
   
   pgadmin:
     container_name: pgadmin_container
-    image: dpage/pgadmin4:4.16
+    image: dpage/pgadmin4
     environment:
       PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-pgadmin4@pgadmin.org}
       PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin}


### PR DESCRIPTION
this change disable server mode. It used to be the default value when unset. Recently pg admin failed to boot because it was running in server mode and not properly configured for that purpose.
See #18 

when SERVER_MODE=False, then data folder is `/root/.pgadmin` and storage folder is `/root/.pgadmin/storage`.
https://www.pgadmin.org/docs/pgadmin4/development/config_py.html#config-py
https://github.com/postgres/pgadmin4/blob/master/web/pgadmin/utils/paths.py

FYI @jaybcee @vanphandinh