### PR TITLE
Mount /var/lib/pgadmin to the host

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## Quick Start
 * Clone or download this repository
 * Go inside of directory,  `cd compose-postgres`
-* Run this command `docker-compose up -d && sudo chown -R 5050:5050 pgadmin`
+* Run this command `docker-compose up -d && sudo chown -R 5050:5050 pgadmin` on Unix-based OS or `docker-compose up -d` on Windows
 
 
 ## Environments

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## Quick Start
 * Clone or download this repository
 * Go inside of directory,  `cd compose-postgres`
-* Run this command `docker-compose up -d`
+* Run this command `docker-compose up -d && sudo chown -R 5050:5050 pgadmin`
 
 
 ## Environments

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,9 +22,8 @@ services:
     environment:
       PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-pgadmin4@pgadmin.org}
       PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin}
-      PGADMIN_CONFIG_SERVER_MODE: 'False'
     volumes:
-       - pgadmin:/root/.pgadmin
+       - ./pgadmin:/var/lib/pgadmin
 
     ports:
       - "${PGADMIN_PORT:-5050}:80"
@@ -38,4 +37,3 @@ networks:
 
 volumes:
     postgres:
-    pgadmin:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-pgadmin4@pgadmin.org}
       PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin}
     volumes:
-       - "./pgadmin:/var/lib/pgadmin:rw"
+       - "./pgadmin:/var/lib/pgadmin:5050:5050"
 
     ports:
       - "${PGADMIN_PORT:-5050}:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-pgadmin4@pgadmin.org}
       PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin}
     volumes:
-       - ./pgadmin:/var/lib/pgadmin
+       - "./pgadmin:/var/lib/pgadmin:rw"
 
     ports:
       - "${PGADMIN_PORT:-5050}:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-pgadmin4@pgadmin.org}
       PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin}
     volumes:
-       - "./pgadmin:/var/lib/pgadmin:5050:5050"
+       - "~/pgadmin:/var/lib/pgadmin:5050:5050"
 
     ports:
       - "${PGADMIN_PORT:-5050}:80"


### PR DESCRIPTION
On this PR, docker mount folder `/var/lib/pgadmin` of the container to folder `${pwd}/pgadmin` of the host.

Following this guide: https://www.pgadmin.org/docs/pgadmin4/latest/container_deployment.html

**/var/lib/pgadmin**

This is the working directory in which pgAdmin stores session data, user files, configuration files, and it’s configuration database. Mapping this directory onto the host machine gives you an easy way to maintain configuration between invocations of the container.

I don't see any docs say about `/root/.pgadmin`