### PR TITLE
Fix pgAdmin volume mounting point

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin}
       PGADMIN_CONFIG_SERVER_MODE: 'False'
     volumes:
-       - pgadmin:/root/.pgadmin
+       - pgadmin:/var/lib/pgadmin
 
     ports:
       - "${PGADMIN_PORT:-5050}:80"


### PR DESCRIPTION
It seems that the pgAdmin settings storage path has changed from the old /root/.pgadmin to /var/lib/pgadmin. THis change has caused that pgAdmin settings are lost between container restarts.