### PR TITLE
turn off logging for pgadmin because it's noisy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
       PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-pgadmin4@pgadmin.org}
       PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin}
       PGADMIN_CONFIG_SERVER_MODE: 'False'
+    logging:
+      driver: "none"
     volumes:
        - pgadmin:/var/lib/pgadmin
 


### PR DESCRIPTION
this is a bit opinionated but the logs have been doing my head in, particularly when you use the container alongside applications that you're trying to develop against.

I've tried disabling them with `GUNICORN_ACCESS_LOGFILE: /dev/null` but that seems to throw an error so I had to be a bit harsher.

happy for this to be declined if it's more of a me issue but I thought I would share it in case it wasn't 🙂